### PR TITLE
fix typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ state = "/tmp/run/containerd"
 Create an RSA key pair using the openssl command line tool and encrypted an image:
 
 ```
-# openssl genrsa --out mykey.pem
+# openssl genrsa -out mykey.pem
 Generating RSA private key, 2048 bit long modulus (2 primes)
 ...............................................+++++
 ............................+++++


### PR DESCRIPTION
try to get start with `readme.md`, find a typo error.

just use one dash for `out` flag

Signed-off-by: Gsealy Jiao <jiaojingwei1001@hotmail.com>