### PR TITLE
ctr-enc support PKCS#11 module

### DIFF
--- a/cmd/ctr/commands/flags/flags.go
+++ b/cmd/ctr/commands/flags/flags.go
@@ -39,6 +39,9 @@ var (
 		}, cli.StringSliceFlag{
 			Name:  "dec-recipient",
 			Usage: "Recipient of the image; used only for PKCS7 and must be an x509 certificate",
+		}, cli.StringFlag{
+			Name:  "p11-module",
+			Usage: "PKCS#11 module path; used only for PKCS11",
 		},
 	}
 )


### PR DESCRIPTION
Related: https://github.com/containers/ocicrypt/pull/18

**usage like:**

```shell
$CTR i encrypt --recipient pkcs11:/usr/local/lib/softhsm/libsofthsm2.so docker.io/library/registry:2.7.1 registry.enc:2.7.1
Encrypting docker.io/library/registry:2.7.1 to registry.enc:2.7.1
Enter Module Password:
$CTR i decrypt --p11-module /usr/local/lib/softhsm/libsofthsm2.so registry.enc:2.7.1 registry:2.7.1
Decrypting registry.enc:2.7.1 to registry:2.7.1
Enter Module Password:
```

**encrypted image layerinfo**
```
$CTR i layerinfo registry.enc:2.7.1
   #                                                                    DIGEST      PLATFORM      SIZE   ENCRYPTION   RECIPIENTS
   0   sha256:e6ac8f3a588c0ea847f5e24562e4b5c80adbfcbfeac2733c2c1c4b790c6c0840   linux/amd64   2813316       pkcs11     [pkcs11]
   1   sha256:6871cd043567f1e28fcd8d45d2a3b475a47b80ea9e3015bed6ea48e853b4d94c   linux/amd64    299598       pkcs11     [pkcs11]
   2   sha256:d97482644a8cf0f49f5d37caf65e01baf0f3f015c50cfacdfc9390e38c3ad4d8   linux/amd64   6823927       pkcs11     [pkcs11]
   3   sha256:4c25c56fdce776c347352b118476618c2e0534fcd21253fded29b4cb096d1c14   linux/amd64       370       pkcs11     [pkcs11]
   4   sha256:893980826f2572d9070e4fc93a245ae9b8a9df2f14df21ae848cf632e8bf22c7   linux/amd64       213       pkcs11     [pkcs11]

```

Signed-off-by: Gsealy Jiao <jiaojingwei1001@hotmail.com>