### PR TITLE
Update to the latest git ocicrypt

### DIFF
--- a/cmd/ctr/commands/images/decrypt.go
+++ b/cmd/ctr/commands/images/decrypt.go
@@ -83,12 +83,7 @@ var decryptCommand = cli.Command{
 			return nil
 		}
 
-		ccopts, err := GetCryptoConfigOpts()
-		if err != nil {
-			return err
-		}
-
-		cc, err := CreateDecryptCryptoConfigWithOpts(context, descs, ccopts)
+		cc, err := CreateDecryptCryptoConfig(context, descs)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/encrypt.go
+++ b/cmd/ctr/commands/images/encrypt.go
@@ -87,12 +87,7 @@ var encryptCommand = cli.Command{
 			return err
 		}
 
-		opts, err := GetCryptoConfigOpts()
-		if err != nil {
-			return err
-		}
-
-		cc, err := CreateCryptoConfigWithOpts(context, descs, opts)
+		cc, err := CreateCryptoConfig(context, descs)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -134,13 +134,8 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			return closeErr
 		}
 
-		ccopts, err := GetCryptoConfigOpts()
-		if err != nil {
-			return err
-		}
-
 		if !context.Bool("no-unpack") {
-			cc, err := CreateDecryptCryptoConfigWithOpts(context, nil, ccopts)
+			cc, err := CreateDecryptCryptoConfig(context, nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/ctr/commands/images/parse_helpers.go
+++ b/cmd/ctr/commands/images/parse_helpers.go
@@ -25,18 +25,13 @@ import (
 
 	"github.com/containers/ocicrypt"
 	encconfig "github.com/containers/ocicrypt/config"
-	"github.com/containers/ocicrypt/crypto/pkcs11"
+	enchelpers "github.com/containers/ocicrypt/helpers"
 	encutils "github.com/containers/ocicrypt/utils"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
-
-// CryptoConfigOpts holds options needed for de- and encryption
-type CryptoConfigOpts struct {
-	Pkcs11Config *pkcs11.Pkcs11Config
-}
 
 // processRecipientKeys sorts the array of recipients by type. Recipients may be either
 // x509 certificates, public keys, or PGP public keys identified by email address or name
@@ -99,7 +94,7 @@ func processRecipientKeys(recipients []string) ([][]byte, [][]byte, [][]byte, []
 		}
 	}
 
-	if len(pkcs11Pubkeys) + len(pkcs11Yamls) > 0 {
+	if len(pkcs11Pubkeys)+len(pkcs11Yamls) > 0 {
 		fmt.Print("WARNING: Pkcs11 support is currently experimental and images encrypted with it will not be decryptable once it is production ready.\n")
 	}
 
@@ -215,7 +210,7 @@ func getGPGPrivateKeys(context *cli.Context, gpgSecretKeyRingFiles [][]byte, des
 // CreateDecryptCryptoConfig creates the CryptoConfig object that contains the necessary
 // information to perform decryption from command line options and possibly
 // LayerInfos describing the image and helping us to query for the PGP decryption keys
-func CreateDecryptCryptoConfigWithOpts(context *cli.Context, descs []ocispec.Descriptor, opts CryptoConfigOpts) (encconfig.CryptoConfig, error) {
+func CreateDecryptCryptoConfigWithOpts(context *cli.Context, descs []ocispec.Descriptor, opts enchelpers.CryptoConfigOpts) (encconfig.CryptoConfig, error) {
 	ccs := []encconfig.CryptoConfig{}
 
 	// x509 cert is needed for PKCS7 decryption
@@ -278,7 +273,7 @@ func CreateDecryptCryptoConfigWithOpts(context *cli.Context, descs []ocispec.Des
 
 // CreateCryptoConfigWithOpts from the list of recipient strings and list of key paths of private keys
 // The opts parameter holds options necessary for de- and encryption, such as when using pkcs11 for example.
-func CreateCryptoConfigWithOpts(context *cli.Context, descs []ocispec.Descriptor, opts CryptoConfigOpts) (encconfig.CryptoConfig, error) {
+func CreateCryptoConfigWithOpts(context *cli.Context, descs []ocispec.Descriptor, opts enchelpers.CryptoConfigOpts) (encconfig.CryptoConfig, error) {
 	recipients := context.StringSlice("recipient")
 	keys := context.StringSlice("key")
 

--- a/cmd/ctr/commands/images/parse_helpers.go
+++ b/cmd/ctr/commands/images/parse_helpers.go
@@ -25,7 +25,8 @@ import (
 
 	"github.com/containers/ocicrypt"
 	encconfig "github.com/containers/ocicrypt/config"
-	enchelpers "github.com/containers/ocicrypt/helpers"
+	"github.com/containers/ocicrypt/config/pkcs11config"
+	"github.com/containers/ocicrypt/crypto/pkcs11"
 	encutils "github.com/containers/ocicrypt/utils"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -210,7 +211,7 @@ func getGPGPrivateKeys(context *cli.Context, gpgSecretKeyRingFiles [][]byte, des
 // CreateDecryptCryptoConfig creates the CryptoConfig object that contains the necessary
 // information to perform decryption from command line options and possibly
 // LayerInfos describing the image and helping us to query for the PGP decryption keys
-func CreateDecryptCryptoConfigWithOpts(context *cli.Context, descs []ocispec.Descriptor, opts enchelpers.CryptoConfigOpts) (encconfig.CryptoConfig, error) {
+func CreateDecryptCryptoConfig(context *cli.Context, descs []ocispec.Descriptor) (encconfig.CryptoConfig, error) {
 	ccs := []encconfig.CryptoConfig{}
 
 	// x509 cert is needed for PKCS7 decryption
@@ -262,25 +263,31 @@ func CreateDecryptCryptoConfigWithOpts(context *cli.Context, descs []ocispec.Des
 	}
 	ccs = append(ccs, privKeysCc)
 
-	pkcs11PrivKeysCc, err := encconfig.DecryptWithPkcs11Yaml(opts.Pkcs11Config, pkcs11Yamls)
-	if err != nil {
-		return encconfig.CryptoConfig{}, err
+	if len(pkcs11Yamls) > 0 {
+		p11conf, err := pkcs11config.GetUserPkcs11Config()
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+
+		pkcs11PrivKeysCc, err := encconfig.DecryptWithPkcs11Yaml(p11conf, pkcs11Yamls)
+		if err != nil {
+			return encconfig.CryptoConfig{}, err
+		}
+		ccs = append(ccs, pkcs11PrivKeysCc)
 	}
-	ccs = append(ccs, pkcs11PrivKeysCc)
 
 	return encconfig.CombineCryptoConfigs(ccs), nil
 }
 
-// CreateCryptoConfigWithOpts from the list of recipient strings and list of key paths of private keys
-// The opts parameter holds options necessary for de- and encryption, such as when using pkcs11 for example.
-func CreateCryptoConfigWithOpts(context *cli.Context, descs []ocispec.Descriptor, opts enchelpers.CryptoConfigOpts) (encconfig.CryptoConfig, error) {
+// CreateCryptoConfig from the list of recipient strings and list of key paths of private keys
+func CreateCryptoConfig(context *cli.Context, descs []ocispec.Descriptor) (encconfig.CryptoConfig, error) {
 	recipients := context.StringSlice("recipient")
 	keys := context.StringSlice("key")
 
 	var decryptCc *encconfig.CryptoConfig
 	ccs := []encconfig.CryptoConfig{}
 	if len(keys) > 0 {
-		dcc, err := CreateDecryptCryptoConfigWithOpts(context, descs, opts)
+		dcc, err := CreateDecryptCryptoConfig(context, descs)
 		if err != nil {
 			return encconfig.CryptoConfig{}, err
 		}
@@ -324,7 +331,14 @@ func CreateCryptoConfigWithOpts(context *cli.Context, descs []ocispec.Descriptor
 		}
 		encryptCcs = append(encryptCcs, jweCc)
 
-		pkcs11Cc, err := encconfig.EncryptWithPkcs11(opts.Pkcs11Config, pkcs11Pubkeys, pkcs11Yamls)
+		var p11conf *pkcs11.Pkcs11Config
+		if len(pkcs11Yamls) > 0 {
+			p11conf, err = pkcs11config.GetUserPkcs11Config()
+			if err != nil {
+				return encconfig.CryptoConfig{}, err
+			}
+		}
+		pkcs11Cc, err := encconfig.EncryptWithPkcs11(p11conf, pkcs11Pubkeys, pkcs11Yamls)
 		if err != nil {
 			return encconfig.CryptoConfig{}, err
 		}

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -110,12 +110,7 @@ command. As part of this process, we do the following:
 			p = append(p, platforms.DefaultSpec())
 		}
 
-		ccopts, err := GetCryptoConfigOpts()
-		if err != nil {
-			return err
-		}
-
-		cc, err := CreateDecryptCryptoConfigWithOpts(context, nil, ccopts)
+		cc, err := CreateDecryptCryptoConfig(context, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -56,11 +56,6 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 		spec  containerd.NewContainerOpts
 	)
 
-	ccopts, err := images.GetCryptoConfigOpts()
-	if err != nil {
-		return nil, err
-	}
-
 	cOpts = append(cOpts, containerd.WithContainerLabels(commands.LabelArgs(context.StringSlice("label"))))
 	if config {
 		opts = append(opts, oci.WithSpecFromFile(context.String("config")))
@@ -103,7 +98,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			}
 
 			if !unpacked {
-				cc, err := images.CreateDecryptCryptoConfigWithOpts(context, nil, ccopts)
+				cc, err := images.CreateDecryptCryptoConfig(context, nil)
 				if err != nil {
 					return nil, err
 				}
@@ -186,7 +181,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 
 	cOpts = append(cOpts, spec)
 
-	cc, err := images.CreateDecryptCryptoConfigWithOpts(context, nil, ccopts)
+	cc, err := images.CreateDecryptCryptoConfig(context, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda // indirect
 	github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8 // indirect
 	github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd
-	github.com/containers/ocicrypt v1.0.4-0.20200924153919-77bf1d8be613
+	github.com/containers/ocicrypt v1.0.4-0.20201019210254-ee875c9741e7
 	github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b // indirect
 	github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible // indirect
 	github.com/docker/go-events v0.0.0-20170721190031-9461782956ad // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,10 +22,10 @@ github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8 h1:jYCTS/16RWXXtV
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd h1:JNn81o/xG+8NEo3bC/vx9pbi/g2WI8mtP2/nXzu297Y=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
-github.com/containers/ocicrypt v1.0.3 h1:vYgl+RZ9Q3DPMuTfxmN+qp0X2Bj52uuY2vnt6GzVe1c=
-github.com/containers/ocicrypt v1.0.3/go.mod h1:CUBa+8MRNL/VkpxYIpaMtgn1WgXGyvPQj8jcy0EVG6g=
-github.com/containers/ocicrypt v1.0.4-0.20200924153919-77bf1d8be613 h1:vdqTyfaysVp5i/znn45rxa1d7CX6l3FKb7pkMDKcbvE=
-github.com/containers/ocicrypt v1.0.4-0.20200924153919-77bf1d8be613/go.mod h1:MV3SVkf23xV764/x6zAcbcUgLy2kDnSrXnEfU5EjmCE=
+github.com/containers/ocicrypt v1.0.4-0.20201015181918-aba5c04c5bfc h1:oLY+S6uKDFl/GYWrvnelSPcVjfL1+GPd/up57+QHgkk=
+github.com/containers/ocicrypt v1.0.4-0.20201015181918-aba5c04c5bfc/go.mod h1:WqIpy4JMdeoYO1onZd5YxgqI/AwbkowmAgVtMcBtR2I=
+github.com/containers/ocicrypt v1.0.4-0.20201019210254-ee875c9741e7 h1:iOR0C/+SyNlEU2H+9rZggsSmR9OoxAzZAW+zWKzWRUk=
+github.com/containers/ocicrypt v1.0.4-0.20201019210254-ee875c9741e7/go.mod h1:WqIpy4JMdeoYO1onZd5YxgqI/AwbkowmAgVtMcBtR2I=
 github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b h1:+mtZ0WjVZwTX0RVrXMXDwuYVaNeHGvWBW1UwJeMR+2M=
 github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
@@ -89,8 +89,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/stefanberger/go-pkcs11uri v0.0.0-20200901134020-a3ec7c3624da h1:nG+J2N1b1YswENeVYY+cHaj/PHvn8EFPMjMmk5vmZTc=
-github.com/stefanberger/go-pkcs11uri v0.0.0-20200901134020-a3ec7c3624da/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
+github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 h1:lIOOHPEbXzO3vnmx2gok1Tfs31Q8GQqKLc8vVqyQq/I=
+github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/script/tests/test_encryption.sh
+++ b/script/tests/test_encryption.sh
@@ -826,14 +826,7 @@ setupPKCS11() {
 	# Env. variable for softhsm_setup
 	export SOFTHSM_SETUP_CONFIGDIR=${WORKDIR}
 	# Env. variable for ctr-enc
-	export IMGCRYPT_CONFIG=${WORKDIR}/imgcrypt.conf
-
-	cat <<_EOF_ > ${IMGCRYPT_CONFIG}
-pkcs11:
-  module-directories:
-    - /usr/lib64/pkcs11/ # Fedora,RedHat,openSUSE
-    - /usr/lib/softhsm/  # Ubuntu,Debian,Alpine
-_EOF_
+	export OCICRYPT_CONFIG=internal
 	SOFTHSM_KEY=${WORKDIR}/softhsm_key.yaml
 
 	output=$(${SOFTHSM_SETUP} setup 2>&1)

--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/cpuguy83/go-md2man v1.0.10
 github.com/russross/blackfriday v1.5.2
 
 # image encryption dependencies
-github.com/containers/ocicrypt 77bf1d8be613123cf54b8a7aa836a400c30dee5b
+github.com/containers/ocicrypt ee875c9741e7e29a869cc8fe7a1b80214cc6b104
 
 # windows
 github.com/Microsoft/go-winio v0.4.14
@@ -45,5 +45,5 @@ gopkg.in/square/go-jose.v2 v2.3.1 https://github.com/square/go-jose.git
 go.mozilla.org/pkcs7 432b2356ecb18209c1cec25680b8a23632794f21 https://github.com/mozilla-services/pkcs7
 
 github.com/miekg/pkcs11 v1.0.3
-github.com/stefanberger/go-pkcs11uri a3ec7c3624da1e310173978935345ef1db12242e
+github.com/stefanberger/go-pkcs11uri 78d3cae3a9805d89aa4fa80a362ca944c89a1b99
 gopkg.in/yaml.v2 v2 https://github.com/go-yaml/yaml

--- a/vendor/github.com/containers/ocicrypt/config/constructors.go
+++ b/vendor/github.com/containers/ocicrypt/config/constructors.go
@@ -75,19 +75,27 @@ func EncryptWithGpg(gpgRecipients [][]byte, gpgPubRingFile []byte) (CryptoConfig
 
 // EncryptWithPkcs11 returns a CryptoConfig to encrypt with configured pkcs11 parameters
 func EncryptWithPkcs11(pkcs11Config *pkcs11.Pkcs11Config, pkcs11Pubkeys, pkcs11Yamls [][]byte) (CryptoConfig, error) {
-	p11confYaml, err := yaml.Marshal(pkcs11Config)
-	if err != nil {
-		return CryptoConfig{}, errors.Wrapf(err, "Could not marshal Pkcs11Config to Yaml")
-	}
+	dc := DecryptConfig{}
+	ep := map[string][][]byte{}
 
-	dc := DecryptConfig{
-		Parameters: map[string][][]byte{
-			"pkcs11-config": {p11confYaml},
-		},
+	if len(pkcs11Yamls) > 0 {
+		if pkcs11Config == nil {
+			return CryptoConfig{}, errors.New("pkcs11Config must not be nil")
+		}
+		p11confYaml, err := yaml.Marshal(pkcs11Config)
+		if err != nil {
+			return CryptoConfig{}, errors.Wrapf(err, "Could not marshal Pkcs11Config to Yaml")
+		}
+
+		dc = DecryptConfig{
+			Parameters: map[string][][]byte{
+				"pkcs11-config": {p11confYaml},
+			},
+		}
+		ep["pkcs11-yamls"] = pkcs11Yamls
 	}
-	ep := map[string][][]byte{
-		"pkcs11-pubkeys": pkcs11Pubkeys,
-		"pkcs11-yamls":   pkcs11Yamls,
+	if len(pkcs11Pubkeys) > 0 {
+		ep["pkcs11-pubkeys"] = pkcs11Pubkeys
 	}
 
 	return CryptoConfig{

--- a/vendor/github.com/containers/ocicrypt/crypto/pkcs11/common.go
+++ b/vendor/github.com/containers/ocicrypt/crypto/pkcs11/common.go
@@ -1,0 +1,134 @@
+/*
+   Copyright The ocicrypt Authors.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pkcs11
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	pkcs11uri "github.com/stefanberger/go-pkcs11uri"
+	"gopkg.in/yaml.v2"
+)
+
+// Pkcs11KeyFile describes the format of the pkcs11 (private) key file.
+// It also carries pkcs11 module related environment variables that are transferred to the
+// Pkcs11URI object and activated when the pkcs11 module is used.
+type Pkcs11KeyFile struct {
+	Pkcs11 struct {
+		Uri string `yaml:"uri"`
+	} `yaml:"pkcs11"`
+	Module struct {
+		Env map[string]string `yaml:"env,omitempty"`
+	} `yaml:"module"`
+}
+
+// Pkcs11KeyFileObject is a representation of the Pkcs11KeyFile with the pkcs11 URI as an object
+type Pkcs11KeyFileObject struct {
+	Uri *pkcs11uri.Pkcs11URI
+}
+
+// ParsePkcs11Uri parses a pkcs11 URI
+func ParsePkcs11Uri(uri string) (*pkcs11uri.Pkcs11URI, error) {
+	p11uri := pkcs11uri.New()
+	err := p11uri.Parse(uri)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not parse Pkcs11URI from file")
+	}
+	return p11uri, err
+}
+
+// ParsePkcs11KeyFile parses a pkcs11 key file holding a pkcs11 URI describing a private key.
+// The file has the following yaml format:
+// pkcs11:
+//  - uri : <pkcs11 uri>
+// An error is returned if the pkcs11 URI is malformed
+func ParsePkcs11KeyFile(yamlstr []byte) (*Pkcs11KeyFileObject, error) {
+	p11keyfile := Pkcs11KeyFile{}
+
+	err := yaml.Unmarshal([]byte(yamlstr), &p11keyfile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not unmarshal pkcs11 keyfile")
+	}
+
+	p11uri, err := ParsePkcs11Uri(p11keyfile.Pkcs11.Uri)
+	if err != nil {
+		return nil, err
+	}
+	p11uri.SetEnvMap(p11keyfile.Module.Env)
+
+	return &Pkcs11KeyFileObject{Uri: p11uri}, err
+}
+
+// IsPkcs11PrivateKey checks whether the given YAML represents a Pkcs11 private key
+func IsPkcs11PrivateKey(yamlstr []byte) bool {
+	_, err := ParsePkcs11KeyFile(yamlstr)
+	return err == nil
+}
+
+// IsPkcs11PublicKey checks whether the given YAML represents a Pkcs11 public key
+func IsPkcs11PublicKey(yamlstr []byte) bool {
+	_, err := ParsePkcs11KeyFile(yamlstr)
+	return err == nil
+}
+
+// Pkcs11Config describes the layout of a pkcs11 config file
+// The file has the following yaml format:
+// module-directories:
+// - /usr/lib64/pkcs11/
+// allowd-module-paths
+// - /usr/lib64/pkcs11/libsofthsm2.so
+type Pkcs11Config struct {
+	ModuleDirectories  []string `yaml:"module-directories"`
+	AllowedModulePaths []string `yaml:"allowed-module-paths"`
+}
+
+// GetDefaultModuleDirectories returns module directories covering
+// a variety of Linux distros
+func GetDefaultModuleDirectories() []string {
+	dirs := []string{
+		"/usr/lib64/pkcs11/", // Fedora,RHEL,openSUSE
+		"/usr/lib/pkcs11/",   // Fedora,ArchLinux
+		"/usr/local/lib/pkcs11/",
+		"/usr/lib/softhsm/", // Debian,Ubuntu
+	}
+
+	// Debian directory: /usr/lib/(x86_64|aarch64|arm|powerpc64le|s390x)-linux-gnu/
+	hosttype, ostype, q := getHostAndOsType()
+	if len(hosttype) > 0 {
+		dir := fmt.Sprintf("/usr/lib/%s-%s-%s/", hosttype, ostype, q)
+		dirs = append(dirs, dir)
+	}
+	return dirs
+}
+
+// GetDefaultModuleDirectoresFormatted returns the default module directories formatted for YAML
+func GetDefaultModuleDirectoriesYaml(indent string) string {
+	res := ""
+
+	for _, dir := range GetDefaultModuleDirectories() {
+		res += indent + "- " + dir + "\n"
+	}
+	return res
+}
+
+// ParsePkcs11ConfigFile parses a pkcs11 config file hat influences the module search behavior
+// as well as the set of modules that users are allowed to use
+func ParsePkcs11ConfigFile(yamlstr []byte) (*Pkcs11Config, error) {
+	p11conf := Pkcs11Config{}
+
+	err := yaml.Unmarshal([]byte(yamlstr), &p11conf)
+	if err != nil {
+		return &p11conf, errors.Wrapf(err, "Could not parse Pkcs11Config")
+	}
+	return &p11conf, nil
+}

--- a/vendor/github.com/containers/ocicrypt/crypto/pkcs11/pkcs11helpers_nocgo.go
+++ b/vendor/github.com/containers/ocicrypt/crypto/pkcs11/pkcs11helpers_nocgo.go
@@ -1,0 +1,31 @@
+// +build !cgo
+
+/*
+   Copyright The ocicrypt Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pkcs11
+
+import (
+	"github.com/pkg/errors"
+)
+
+func EncryptMultiple(pubKeys []interface{}, data []byte) ([]byte, error) {
+	return nil, errors.Errorf("ocicrypt pkcs11 not supported on this build")
+}
+
+func Decrypt(privKeyObjs []*Pkcs11KeyFileObject, pkcs11blobstr []byte) ([]byte, error) {
+	return nil, errors.Errorf("ocicrypt pkcs11 not supported on this build")
+}


### PR DESCRIPTION
Update to the latest ocicrypt and adjust the code accordingly. Ocicrypt
now gets the user-provided configuration for pkcs11 only if a pkcs11 key
in yaml format is provided. This avoids unnecessary error messages if for
example an image is pulled but doesn't need pkcs11 configuration since
no keys are needed since it doesn't need to be decrypted. Also, the helper
functions ending in 'WithOpts' do not exist anymore and so we roll back some
of the previous changes.
    
Also, due to the changes, the config file is searched for in this order:
- ${OCICRYPT_CONFIG}="internal": use an internal allow-all policy
- ${OCICRYPT_CONFIG}
- ${XDG_CONFIG_HOME}/ocicrypt.conf
- ${HOME}/.config/ocicrypt.conf
- /etc/ocicrypt.conf
    
The previously used IMGCRYPT_CONFIG variable is not used anymore.
