### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# imgcrypt image encryption library and command line lool
+# imgcrypt image encryption library and command line tool
 
 Project `imgcrypt` is a non-core subproject of containerd.
 


### PR DESCRIPTION
Fix typo as highlighted from inactive PRs: https://github.com/containerd/imgcrypt/pull/5 and https://github.com/containerd/imgcrypt/pull/3


Signed-off-by: Brandon Lum <lumjjb@gmail.com>