### PR TITLE
tests: Allow passing pull credentials using IMAGE_PULL_CREDS

### DIFF
--- a/script/tests/test_encryption.sh
+++ b/script/tests/test_encryption.sh
@@ -159,11 +159,14 @@ failExit() {
 }
 
 pullImages() {
+	if [ -z "$IMAGE_PULL_CREDS" ]; then
+		echo "Note: Image pull credentials can be passed with env. variable IMAGE_PULL_CREDS=<username>:<password>"
+	fi
 	$CTR images rm --sync ${ALPINE_ENC} ${ALPINE_DEC} ${NGINX_ENC} ${NGINX_DEC} &>/dev/null
-	$CTR images pull --all-platforms ${ALPINE} &>/dev/null
+	$CTR images pull ${IMAGE_PULL_CREDS:+--user ${IMAGE_PULL_CREDS}} --all-platforms ${ALPINE} &>/dev/null
 	failExit $? "Image pull failed on ${ALPINE}"
 
-	$CTR images pull --platform linux/amd64 ${NGINX} &>/dev/null
+	$CTR images pull ${IMAGE_PULL_CREDS:+--user ${IMAGE_PULL_CREDS}} --platform linux/amd64 ${NGINX} &>/dev/null
 	failExit $? "Image pull failed on ${NGINX}"
 
 	LAYER_INFO_ALPINE="$($CTR images layerinfo ${ALPINE})"


### PR DESCRIPTION
To avoid errors when pulling images from docker hub, allow passing
pull credentials using IMAGE_PULL_CREDS.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>