### PR TITLE
Decouple CreateCryptoConfig() from github.com/urfave/cli

### DIFF
--- a/cmd/ctr/commands/images/crypt_utils.go
+++ b/cmd/ctr/commands/images/crypt_utils.go
@@ -26,7 +26,9 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/imgcrypt/cmd/ctr/commands/img"
 	imgenc "github.com/containerd/imgcrypt/images/encryption"
+	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
 	encconfig "github.com/containers/ocicrypt/config"
+	"github.com/urfave/cli"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -237,4 +239,14 @@ func parsePlatformArray(specifiers []string) ([]ocispec.Platform, error) {
 		speclist = append(speclist, spec)
 	}
 	return speclist, nil
+}
+
+func ParseEncArgs(context *cli.Context) parsehelpers.EncArgs {
+	return parsehelpers.EncArgs{
+		GPGHomedir:   context.String("gpg-homedir"),
+		GPGVersion:   context.String("gpg-version"),
+		Key:          context.StringSlice("key"),
+		Recipient:    context.StringSlice("recipient"),
+		DecRecipient: context.StringSlice("dec-recipient"),
+	}
 }

--- a/cmd/ctr/commands/images/decrypt.go
+++ b/cmd/ctr/commands/images/decrypt.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/imgcrypt/cmd/ctr/commands/flags"
 	imgenc "github.com/containerd/imgcrypt/images/encryption"
+	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
 
 	"github.com/urfave/cli"
 )
@@ -84,7 +85,7 @@ var decryptCommand = cli.Command{
 			return nil
 		}
 
-		cc, err := CreateDecryptCryptoConfig(context, descs)
+		cc, err := parsehelpers.CreateDecryptCryptoConfig(ParseEncArgs(context), descs)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/encrypt.go
+++ b/cmd/ctr/commands/images/encrypt.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/imgcrypt/cmd/ctr/commands/flags"
+	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
 
 	"github.com/urfave/cli"
 )
@@ -88,7 +89,7 @@ var encryptCommand = cli.Command{
 			return err
 		}
 
-		cc, err := CreateCryptoConfig(context, descs)
+		cc, err := parsehelpers.CreateCryptoConfig(ParseEncArgs(context), descs)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/imgcrypt"
 	"github.com/containerd/imgcrypt/cmd/ctr/commands/flags"
 	"github.com/containerd/imgcrypt/images/encryption"
+	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
 	"github.com/urfave/cli"
 )
 
@@ -135,7 +136,7 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 		}
 
 		if !context.Bool("no-unpack") {
-			cc, err := CreateDecryptCryptoConfig(context, nil)
+			cc, err := parsehelpers.CreateDecryptCryptoConfig(ParseEncArgs(context), nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/ctr/commands/images/layerinfo.go
+++ b/cmd/ctr/commands/images/layerinfo.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
 	"github.com/containers/ocicrypt"
 
 	"github.com/urfave/cli"
@@ -84,7 +85,7 @@ var layerinfoCommand = cli.Command{
 		var gpgClient ocicrypt.GPGClient
 		if !context.Bool("n") {
 			// create a GPG client to resolve keyIds to names
-			gpgClient, _ = createGPGClient(context)
+			gpgClient, _ = parsehelpers.CreateGPGClient(ParseEncArgs(context))
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.AlignRight)

--- a/cmd/ctr/commands/images/pull.go
+++ b/cmd/ctr/commands/images/pull.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/imgcrypt"
 	"github.com/containerd/imgcrypt/cmd/ctr/commands/flags"
 	"github.com/containerd/imgcrypt/images/encryption"
+	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
 
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -125,7 +126,7 @@ command. As part of this process, we do the following:
 			p = append(p, platforms.DefaultSpec())
 		}
 
-		cc, err := CreateDecryptCryptoConfig(context, nil)
+		cc, err := parsehelpers.CreateDecryptCryptoConfig(ParseEncArgs(context), nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -38,6 +38,7 @@ import (
 	"github.com/containerd/imgcrypt/cmd/ctr/commands"
 	"github.com/containerd/imgcrypt/cmd/ctr/commands/images"
 	"github.com/containerd/imgcrypt/images/encryption"
+	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
@@ -142,7 +143,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 				return nil, err
 			}
 			if !unpacked {
-				cc, err := images.CreateDecryptCryptoConfig(context, nil)
+				cc, err := parsehelpers.CreateDecryptCryptoConfig(images.ParseEncArgs(context), nil)
 				if err != nil {
 					return nil, err
 				}
@@ -293,7 +294,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 
 	cOpts = append(cOpts, spec)
 
-	cc, err := images.CreateDecryptCryptoConfig(context, nil)
+	cc, err := parsehelpers.CreateDecryptCryptoConfig(images.ParseEncArgs(context), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/imgcrypt/cmd/ctr/commands"
 	"github.com/containerd/imgcrypt/cmd/ctr/commands/images"
 	"github.com/containerd/imgcrypt/images/encryption"
+	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -87,7 +88,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			return nil, err
 		}
 		if !unpacked {
-			cc, err := images.CreateDecryptCryptoConfig(context, nil)
+			cc, err := parsehelpers.CreateDecryptCryptoConfig(images.ParseEncArgs(context), nil)
 			if err != nil {
 				return nil, err
 			}
@@ -152,7 +153,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 
 	cOpts = append(cOpts, spec)
 
-	cc, err := images.CreateDecryptCryptoConfig(context, nil)
+	cc, err := parsehelpers.CreateDecryptCryptoConfig(images.ParseEncArgs(context), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Decouple `CreateCryptoConfig()` from `github.com/urfave/cli`, so that it can be called from other applications that do not use `github.com/urfave/cli`.

