### PR TITLE
maint: Update to ocicrypt v1.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/containerd/containerd v1.5.7
 	github.com/containerd/go-cni v1.1.0
 	github.com/containerd/typeurl v1.0.2
-	github.com/containers/ocicrypt v1.1.1
+	github.com/containers/ocicrypt v1.1.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,9 @@ github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHV
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
 github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgUV4GP9qXPfu4=
-github.com/containers/ocicrypt v1.1.1 h1:prL8l9w3ntVqXvNH1CiNn5ENjcCnr38JqpSyvKKB4GI=
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
+github.com/containers/ocicrypt v1.1.2 h1:Ez+GAMP/4GLix5Ywo/fL7O0nY771gsBIigiqUm1aXz0=
+github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=

--- a/vendor/github.com/containers/ocicrypt/ADOPTERS.md
+++ b/vendor/github.com/containers/ocicrypt/ADOPTERS.md
@@ -1,0 +1,10 @@
+Below are list of adopters of the `ocicrypt` library or supports use of OCI encrypted images:
+- [skopeo](https://github.com/containers/skopeo)
+- [buildah](https://github.com/containers/buildah)
+- [containerd](https://github.com/containerd/imgcrypt)
+- [nerdctl](https://github.com/containerd/nerdctl)
+- [distribution](https://github.com/distribution/distribution)
+
+Below are the list of projects that are in the process of adopting support:
+- [quay](https://github.com/quay/quay)
+- [kata-containers](https://github.com/kata-containers/kata-containers)

--- a/vendor/github.com/containers/ocicrypt/README.md
+++ b/vendor/github.com/containers/ocicrypt/README.md
@@ -34,6 +34,12 @@ The implementation for both symmetric and asymmetric encryption used in this lib
 
 We note that adding interfaces here is risky outside the OCI spec is not recommended, unless for very specialized and confined usecases. Please open an issue or PR if there is a general usecase that could be added to the OCI spec.
 
+
+#### Keyprovider interface
+
+As part of the keywrap interface, there is a [keyprovider](https://github.com/containers/ocicrypt/blob/main/docs/keyprovider.md) implementation that allows one to call out to a binary or service.
+
+
 ## Security Issues
 
 We consider security issues related to this library critical. Please report and security related issues by emailing maintainers in the [MAINTAINERS](MAINTAINERS) file.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/containernetworking/cni/pkg/types/create
 github.com/containernetworking/cni/pkg/types/internal
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/containers/ocicrypt v1.1.1
+# github.com/containers/ocicrypt v1.1.2
 ## explicit
 github.com/containers/ocicrypt
 github.com/containers/ocicrypt/blockcipher


### PR DESCRIPTION
Update to ocicrypt v1.1.2. Not much seems to have changed there code-wise.

signed-off-by: Stefan Berger <stefanb@linux.ibm.com>