### PR TITLE
docs: update project branch to main

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,7 @@
 # imgcrypt maintainers
 #
-# As a containerd sub-project, containerd maintainers are also included from https://github.com/containerd/project/blob/master/MAINTAINERS.
-# See https://github.com/containerd/project/blob/master/GOVERNANCE.md for description of maintainer role
+# As a containerd sub-project, containerd maintainers are also included from https://github.com/containerd/project/blob/main/MAINTAINERS.
+# See https://github.com/containerd/project/blob/main/GOVERNANCE.md for description of maintainer role
 #
 # MAINTAINERS
 # GitHub ID, Name, Email address

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Hello World!
 
 **imgcrypt** is a non-core containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
 As a containerd sub-project, you will find the:
- * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Project governance](https://github.com/containerd/project/blob/main/GOVERNANCE.md),
  * [Maintainers](MAINTAINERS),
- * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/main/CONTRIBUTING.md)
 
 information in our [`containerd/project`](https://github.com/containerd/project) repository.


### PR DESCRIPTION
The https://github.com/containerd/project repository changed its default branch from master to main.  This commit updates the references to that project repository in the README.md and MAINTAINERS files.
