### PR TITLE
Use reflect to support diff.ApplyConfig with/without gogo's types.Any

### DIFF
--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -282,7 +282,7 @@ var infoCommand = cli.Command{
 			return nil
 		}
 
-		if info.Spec != nil && info.Spec.Value != nil {
+		if info.Spec != nil && info.Spec.GetValue() != nil {
 			v, err := typeurl.UnmarshalAny(info.Spec)
 			if err != nil {
 				return err

--- a/images/encryption/any.go
+++ b/images/encryption/any.go
@@ -18,8 +18,6 @@ package encryption
 
 import "github.com/gogo/protobuf/types"
 
-type anyMap map[string]*types.Any
-
 type any interface {
 	GetTypeUrl() string
 	GetValue() []byte

--- a/images/encryption/client.go
+++ b/images/encryption/client.go
@@ -34,19 +34,14 @@ import (
 // WithDecryptedUnpack allows to pass parameters the 'layertool' needs to the applier
 func WithDecryptedUnpack(data *imgcrypt.Payload) diff.ApplyOpt {
 	return func(_ context.Context, desc ocispec.Descriptor, c *diff.ApplyConfig) error {
-		if c.ProcessorPayloads == nil {
-			c.ProcessorPayloads = make(anyMap)
-		}
 		data.Descriptor = desc
 		any, err := typeurl.MarshalAny(data)
 		if err != nil {
 			return fmt.Errorf("failed to marshal payload: %w", err)
 		}
 
-		pbany := fromAny(any)
-
 		for _, id := range imgcrypt.PayloadToolIDs {
-			c.ProcessorPayloads[id] = pbany
+			setProcessorPayload(c, id, any)
 		}
 		return nil
 	}

--- a/images/encryption/payload.go
+++ b/images/encryption/payload.go
@@ -1,0 +1,53 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package encryption
+
+import (
+	"reflect"
+
+	"github.com/containerd/containerd/diff"
+	"github.com/gogo/protobuf/types"
+)
+
+var processorPayloadsUseGogo bool
+
+func init() {
+	var c = &diff.ApplyConfig{}
+	var pbany *types.Any
+
+	pp := reflect.TypeOf(c.ProcessorPayloads)
+	processorPayloadsUseGogo = pp.Elem() == reflect.TypeOf(pbany)
+}
+
+func clearProcessorPayloads(c *diff.ApplyConfig) {
+	var empty = reflect.MakeMap(reflect.TypeOf(c.ProcessorPayloads))
+	reflect.ValueOf(&c.ProcessorPayloads).Elem().Set(empty)
+}
+
+func setProcessorPayload(c *diff.ApplyConfig, id string, value any) {
+	if c.ProcessorPayloads == nil {
+		clearProcessorPayloads(c)
+	}
+
+	var v reflect.Value
+	if processorPayloadsUseGogo {
+		v = reflect.ValueOf(fromAny(value))
+	} else {
+		v = reflect.ValueOf(value)
+	}
+	reflect.ValueOf(c.ProcessorPayloads).SetMapIndex(reflect.ValueOf(id), v)
+}

--- a/images/encryption/payload_test.go
+++ b/images/encryption/payload_test.go
@@ -1,0 +1,59 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package encryption
+
+import (
+	"testing"
+
+	"github.com/containerd/containerd/diff"
+	"github.com/gogo/protobuf/types"
+)
+
+func TestInit(t *testing.T) {
+	if !processorPayloadsUseGogo {
+		t.Fatalf("failed to detect gogo: %v", processorPayloadsUseGogo)
+	}
+}
+
+func TestClear(t *testing.T) {
+	var ac diff.ApplyConfig
+	clearProcessorPayloads(&ac)
+	if ac.ProcessorPayloads == nil {
+		t.Fatalf("ProcessorPayloads must have a map, but got %v", ac.ProcessorPayloads)
+	}
+
+	_, ok := ac.ProcessorPayloads["hello"]
+	if ok {
+		t.Fatalf("expected false, but got %v", ok)
+	}
+}
+
+func TestSet(t *testing.T) {
+	var ac diff.ApplyConfig
+
+	expected := &types.Any{}
+	setProcessorPayload(&ac, "hello", expected)
+
+	got, ok := ac.ProcessorPayloads["hello"]
+	if !ok {
+		t.Fatalf("expected false, but got %v", ok)
+	}
+
+	if got != expected {
+		t.Fatalf("expected %v, but got %v", expected, got)
+	}
+}


### PR DESCRIPTION
containerd is migrating off from github.com/gogo/protobuf
(see https://github.com/containerd/containerd/issues/6564).
  
However imgcrypt depends containerd and containerd also depends
imgcrypt, which makes changing this signature complicated.
    
This change workarounds the issue by using Go's reflect package.
