### PR TITLE
CI: Upgrade to golangci-lint v1.46.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.46.2
           working-directory: src/github.com/containerd/imgcrypt
 
   tests:


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>