### PR TITLE
Update to min golang 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
 
       - name: Set env
         shell: bash
@@ -61,7 +61,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        go: [1.17, 1.18]
+        go: [1.18, 1.19]
         os: [ubuntu-18.04, windows-2019]
 
     name: Tests / ${{ matrix.os }} / ${{ matrix.go }}


### PR DESCRIPTION
github.com/containerd/containerd/runtime now requires 1.18 

Signed-off-by: Brandon Lum <lumjjb@gmail.com>