### PR TITLE
Fix issue 89

### DIFF
--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -184,7 +184,11 @@ decrypting the image later on.
 
 				// TODO: Show unpack status
 				fmt.Printf("unpacking %s (%s)...", img.Name, img.Target.Digest)
-				err = image.Unpack(ctx, context.String("snapshotter"), opts)
+				if context.IsSet("skip-decrypt-auth") {
+					err = image.Unpack(ctx, context.String("snapshotter"))
+				} else {
+					err = image.Unpack(ctx, context.String("snapshotter"), opts)
+				}
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This PR fixes issue #89 by implementing support for `--skip-decrypt-auth` in the `ctr-enc import` command.

It also syncs the import command with the upstream `ctr import` command and adds support for `--platform`.