### PR TITLE
Sync import options with upstream ctr and document requirements for importing encrypted images

### DIFF
--- a/cmd/ctr/commands/images/encrypt.go
+++ b/cmd/ctr/commands/images/encrypt.go
@@ -55,6 +55,9 @@ var encryptCommand = cli.Command{
 	}, cli.IntSliceFlag{
 		Name:  "layer",
 		Usage: "The layer to encrypt; this must be either the layer number or a negative number starting with -1 for topmost layer",
+	}, cli.BoolFlag{
+		Name:  "all-platforms",
+		Usage: "encrypt for all platforms; this is the default",
 	}, cli.StringSliceFlag{
 		Name:  "platform",
 		Usage: "For which platform to encrypt; by default encrytion is done for all platforms",

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/imgcrypt"
 	"github.com/containerd/imgcrypt/cmd/ctr/commands/flags"
 	"github.com/containerd/imgcrypt/images/encryption"
@@ -72,6 +73,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			Name:  "all-platforms",
 			Usage: "imports content for all platforms, false by default",
 		},
+		cli.StringFlag{
+			Name:  "platform",
+			Usage: "imports content for specific platform",
+		},
 		cli.BoolFlag{
 			Name:  "no-unpack",
 			Usage: "skip unpacking the images, false by default",
@@ -84,8 +89,9 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 	Action: func(context *cli.Context) error {
 		var (
-			in   = context.Args().First()
-			opts []containerd.ImportOpt
+			in             = context.Args().First()
+			opts           []containerd.ImportOpt
+			platformMacher platforms.MatchComparer
 		)
 
 		prefix := context.String("base-name")
@@ -107,6 +113,15 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 		if context.Bool("compress-blobs") {
 			opts = append(opts, containerd.WithImportCompression())
+		}
+
+		if platform := context.String("platform"); platform != "" {
+			platSpec, err := platforms.Parse(platform)
+			if err != nil {
+				return err
+			}
+			platformMacher = platforms.Only(platSpec)
+			opts = append(opts, containerd.WithImportPlatform(platformMacher))
 		}
 
 		opts = append(opts, containerd.WithAllPlatforms(context.Bool("all-platforms")))
@@ -148,8 +163,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			log.G(ctx).Debugf("unpacking %d images", len(imgs))
 
 			for _, img := range imgs {
-				// TODO: Allow configuration of the platform
-				image := containerd.NewImage(client, img)
+				if platformMacher == nil { // if platform not specified use default.
+					platformMacher = platforms.Default()
+				}
+				image := containerd.NewImageWithPlatform(client, img, platformMacher)
 
 				// TODO: Show unpack status
 				fmt.Printf("unpacking %s (%s)...", img.Name, img.Target.Digest)

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -54,6 +54,10 @@ e.g.
 
 If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadbeef", the command will create
 "foo/bar:latest" and "foo/bar@sha256:deadbeef" images in the containerd store.
+
+Import of an encrypted image requires the decryption key to be passed. Even though the image will not be
+decrypted it is required that the user proofs to be in possession of one of the decryption keys needed for
+decrypting the image later on.
 `,
 	Flags: append(append([]cli.Flag{
 		cli.StringFlag{

--- a/cmd/ctr/commands/images/import.go
+++ b/cmd/ctr/commands/images/import.go
@@ -65,6 +65,10 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 			Name:  "digests",
 			Usage: "whether to create digest images (default: false)",
 		},
+		cli.BoolFlag{
+			Name:  "skip-digest-for-named",
+			Usage: "skip applying --digests option to images named in the importing tar (use it in conjunction with --digests)",
+		},
 		cli.StringFlag{
 			Name:  "index-name",
 			Usage: "image name to keep index as, by default index is discarded",
@@ -105,6 +109,12 @@ If foobar.tar contains an OCI ref named "latest" and anonymous ref "sha256:deadb
 
 		if context.Bool("digests") {
 			opts = append(opts, containerd.WithDigestRef(archive.DigestTranslator(prefix)))
+		}
+		if context.Bool("skip-digest-for-named") {
+			if !context.Bool("digests") {
+				return fmt.Errorf("--skip-digest-for-named must be specified with --digests option")
+			}
+			opts = append(opts, containerd.WithSkipDigestRef(func(name string) bool { return name != "" }))
 		}
 
 		if idxName := context.String("index-name"); idxName != "" {


### PR DESCRIPTION
This PR

- syncs ctr-enc with upstream ctr's options
- documents that a key is required for import of an encrypted image
- adds the option '--all-platforms' to the encrypt command