### PR TITLE
Update to ocicrypt 1.1.6 and add support for zstd type of compressed layers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ state = "/tmp/run/containerd"
         accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
         returns = "application/vnd.oci.image.layer.v1.tar+gzip"
         path = "/usr/local/bin/ctd-decoder"
+    [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.zstd"]
+        accepts = ["application/vnd.oci.image.layer.v1.tar+zstd+encrypted"]
+        returns = "application/vnd.oci.image.layer.v1.tar+zstd"
+        path = "/usr/local/bin/ctd-decoder"
     [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
         accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
         returns = "application/vnd.oci.image.layer.v1.tar"

--- a/cmd/ctr/commands/img/utils.go
+++ b/cmd/ctr/commands/img/utils.go
@@ -57,8 +57,9 @@ func GetImageLayerDescriptors(ctx context.Context, cs content.Store, desc ocispe
 
 			switch child.MediaType {
 			case images.MediaTypeDockerSchema2LayerGzip, images.MediaTypeDockerSchema2Layer,
-				ocispec.MediaTypeImageLayerGzip, ocispec.MediaTypeImageLayer,
-				encocispec.MediaTypeLayerGzipEnc, encocispec.MediaTypeLayerEnc:
+				ocispec.MediaTypeImageLayerGzip, ocispec.MediaTypeImageLayerZstd, ocispec.MediaTypeImageLayer,
+				encocispec.MediaTypeLayerGzipEnc, encocispec.MediaTypeLayerEnc,
+				encocispec.MediaTypeLayerZstdEnc:
 				tdesc := child
 				tdesc.Platform = platform
 				tmp = append(tmp, tdesc)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/containerd/containerd v1.6.8
 	github.com/containerd/go-cni v1.1.6
 	github.com/containerd/typeurl v1.0.2
-	github.com/containers/ocicrypt v1.1.5
+	github.com/containers/ocicrypt v1.1.6
 	github.com/gogo/protobuf v1.3.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgU
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/containers/ocicrypt v1.1.2/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/containers/ocicrypt v1.1.3/go.mod h1:xpdkbVAuaH3WzbEabUd5yDsl9SwJA5pABH85425Es2g=
-github.com/containers/ocicrypt v1.1.5 h1:UO+gBnBXvMvC7HTXLh0bPgLslfW8HlY+oxYcoSHBcZQ=
-github.com/containers/ocicrypt v1.1.5/go.mod h1:WgjxPWdTJMqYMjf3M6cuIFFA1/MpyyhIM99YInA+Rvc=
+github.com/containers/ocicrypt v1.1.6 h1:uoG52u2e91RE4UqmBICZY8dNshgfvkdl3BW6jnxiFaI=
+github.com/containers/ocicrypt v1.1.6/go.mod h1:WgjxPWdTJMqYMjf3M6cuIFFA1/MpyyhIM99YInA+Rvc=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/images/encryption/encryption.go
+++ b/images/encryption/encryption.go
@@ -60,7 +60,7 @@ func isLocalPlatform(platform *ocispec.Platform) bool {
 // IsEncryptedDiff returns true if mediaType is a known encrypted media type.
 func IsEncryptedDiff(ctx context.Context, mediaType string) bool {
 	switch mediaType {
-	case encocispec.MediaTypeLayerGzipEnc, encocispec.MediaTypeLayerEnc:
+	case encocispec.MediaTypeLayerZstdEnc, encocispec.MediaTypeLayerGzipEnc, encocispec.MediaTypeLayerEnc:
 		return true
 	}
 	return false
@@ -113,12 +113,16 @@ func encryptLayer(cc *encconfig.CryptoConfig, dataReader content.ReaderAt, desc 
 		newDesc.MediaType = encocispec.MediaTypeLayerEnc
 	case encocispec.MediaTypeLayerGzipEnc:
 		newDesc.MediaType = encocispec.MediaTypeLayerGzipEnc
+	case encocispec.MediaTypeLayerZstdEnc:
+		newDesc.MediaType = encocispec.MediaTypeLayerZstdEnc
 	case encocispec.MediaTypeLayerEnc:
 		newDesc.MediaType = encocispec.MediaTypeLayerEnc
 
 	// TODO: Mediatypes to be added in ocispec
 	case ocispec.MediaTypeImageLayerGzip:
 		newDesc.MediaType = encocispec.MediaTypeLayerGzipEnc
+	case ocispec.MediaTypeImageLayerZstd:
+		newDesc.MediaType = encocispec.MediaTypeLayerZstdEnc
 	case ocispec.MediaTypeImageLayer:
 		newDesc.MediaType = encocispec.MediaTypeLayerEnc
 
@@ -145,6 +149,8 @@ func DecryptLayer(dc *encconfig.DecryptConfig, dataReader io.Reader, desc ocispe
 	switch desc.MediaType {
 	case encocispec.MediaTypeLayerGzipEnc:
 		newDesc.MediaType = images.MediaTypeDockerSchema2LayerGzip
+	case encocispec.MediaTypeLayerZstdEnc:
+		newDesc.MediaType = ocispec.MediaTypeImageLayerZstd
 	case encocispec.MediaTypeLayerEnc:
 		newDesc.MediaType = images.MediaTypeDockerSchema2Layer
 	default:
@@ -170,6 +176,8 @@ func decryptLayer(cc *encconfig.CryptoConfig, dataReader content.ReaderAt, desc 
 	switch desc.MediaType {
 	case encocispec.MediaTypeLayerGzipEnc:
 		newDesc.MediaType = images.MediaTypeDockerSchema2LayerGzip
+	case encocispec.MediaTypeLayerZstdEnc:
+		newDesc.MediaType = ocispec.MediaTypeImageLayerZstd
 	case encocispec.MediaTypeLayerEnc:
 		newDesc.MediaType = images.MediaTypeDockerSchema2Layer
 	default:
@@ -284,7 +292,8 @@ func cryptChildren(ctx context.Context, cs content.Store, desc ocispec.Descripto
 		case images.MediaTypeDockerSchema2Config, ocispec.MediaTypeImageConfig:
 			config = child
 		case images.MediaTypeDockerSchema2LayerGzip, images.MediaTypeDockerSchema2Layer,
-			ocispec.MediaTypeImageLayerGzip, ocispec.MediaTypeImageLayer:
+			ocispec.MediaTypeImageLayerGzip, ocispec.MediaTypeImageLayer,
+			ocispec.MediaTypeImageLayerZstd:
 			if cryptoOp == cryptoOpEncrypt && lf(child) {
 				nl, err := cryptLayer(ctx, cs, child, cc, cryptoOp)
 				if err != nil {
@@ -295,7 +304,7 @@ func cryptChildren(ctx context.Context, cs content.Store, desc ocispec.Descripto
 			} else {
 				newLayers = append(newLayers, child)
 			}
-		case encocispec.MediaTypeLayerGzipEnc, encocispec.MediaTypeLayerEnc:
+		case encocispec.MediaTypeLayerGzipEnc, encocispec.MediaTypeLayerZstdEnc, encocispec.MediaTypeLayerEnc:
 			// this one can be decrypted but also its recipients list changed
 			if lf(child) {
 				nl, err := cryptLayer(ctx, cs, child, cc, cryptoOp)

--- a/script/tests/test_encryption.sh
+++ b/script/tests/test_encryption.sh
@@ -91,6 +91,11 @@ state = "${STATEDIR}"
 	returns = "application/vnd.oci.image.layer.v1.tar+gzip"
 	path = "${BIN}/ctd-decoder"
 
+    [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.zstd"]
+	accepts = ["application/vnd.oci.image.layer.v1.tar+zstd+encrypted"]
+	returns = "application/vnd.oci.image.layer.v1.tar+zstd"
+	path = "${BIN}/ctd-decoder"
+
     [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
 	accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
 	returns = "application/vnd.oci.image.layer.v1.tar"
@@ -127,6 +132,12 @@ state = "${STATEDIR}"
     [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
 	accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
 	returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+	path = "${BIN}/ctd-decoder"
+	args = ["--decryption-keys-path", "${LOCAL_KEYS_PATH}"]
+
+    [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.zstd"]
+	accepts = ["application/vnd.oci.image.layer.v1.tar+zsdt+encrypted"]
+	returns = "application/vnd.oci.image.layer.v1.tar+zstd"
 	path = "${BIN}/ctd-decoder"
 	args = ["--decryption-keys-path", "${LOCAL_KEYS_PATH}"]
 

--- a/vendor/github.com/containers/ocicrypt/encryption.go
+++ b/vendor/github.com/containers/ocicrypt/encryption.go
@@ -33,9 +33,9 @@ import (
 	"github.com/containers/ocicrypt/keywrap/pkcs11"
 	"github.com/containers/ocicrypt/keywrap/pkcs7"
 	"github.com/opencontainers/go-digest"
-	log "github.com/sirupsen/logrus"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 // EncryptLayerFinalizer is a finalizer run to return the annotations to set for
@@ -143,6 +143,9 @@ func EncryptLayer(ec *config.EncryptConfig, encOrPlainLayerReader io.Reader, des
 
 		newAnnotations := make(map[string]string)
 		keysWrapped := false
+		if len(keyWrapperAnnotations) == 0 {
+			return nil, errors.New("missing Annotations needed for decryption")
+		}
 		for annotationsID, scheme := range keyWrapperAnnotations {
 			b64Annotations := desc.Annotations[annotationsID]
 			keywrapper := GetKeyWrapper(scheme)
@@ -211,6 +214,9 @@ func DecryptLayer(dc *config.DecryptConfig, encLayerReader io.Reader, desc ocisp
 func decryptLayerKeyOptsData(dc *config.DecryptConfig, desc ocispec.Descriptor) ([]byte, error) {
 	privKeyGiven := false
 	errs := ""
+	if len(keyWrapperAnnotations) == 0 {
+		return nil, errors.New("missing Annotations needed for decryption")
+	}
 	for annotationsID, scheme := range keyWrapperAnnotations {
 		b64Annotation := desc.Annotations[annotationsID]
 		if b64Annotation != "" {

--- a/vendor/github.com/containers/ocicrypt/keywrap/pkcs11/keywrapper_pkcs11.go
+++ b/vendor/github.com/containers/ocicrypt/keywrap/pkcs11/keywrapper_pkcs11.go
@@ -139,7 +139,7 @@ func addPubKeys(dc *config.DecryptConfig, pubKeys [][]byte) ([]interface{}, erro
 	return pkcs11Keys, nil
 }
 
-func p11confFromParameters(dcparameters map[string][][]byte) (*pkcs11.Pkcs11Config, error){
+func p11confFromParameters(dcparameters map[string][][]byte) (*pkcs11.Pkcs11Config, error) {
 	if _, ok := dcparameters["pkcs11-config"]; ok {
 		return pkcs11.ParsePkcs11ConfigFile(dcparameters["pkcs11-config"][0])
 	}

--- a/vendor/github.com/containers/ocicrypt/spec/spec.go
+++ b/vendor/github.com/containers/ocicrypt/spec/spec.go
@@ -3,10 +3,14 @@ package spec
 const (
 	// MediaTypeLayerEnc is MIME type used for encrypted layers.
 	MediaTypeLayerEnc = "application/vnd.oci.image.layer.v1.tar+encrypted"
-	// MediaTypeLayerGzipEnc is MIME type used for encrypted compressed layers.
+	// MediaTypeLayerGzipEnc is MIME type used for encrypted gzip-compressed layers.
 	MediaTypeLayerGzipEnc = "application/vnd.oci.image.layer.v1.tar+gzip+encrypted"
+	// MediaTypeLayerZstdEnc is MIME type used for encrypted zstd-compressed layers.
+	MediaTypeLayerZstdEnc = "application/vnd.oci.image.layer.v1.tar+zstd+encrypted"
 	// MediaTypeLayerNonDistributableEnc is MIME type used for non distributable encrypted layers.
 	MediaTypeLayerNonDistributableEnc = "application/vnd.oci.image.layer.nondistributable.v1.tar+encrypted"
-	// MediaTypeLayerGzipEnc is MIME type used for non distributable encrypted compressed layers.
+	// MediaTypeLayerGzipEnc is MIME type used for non distributable encrypted gzip-compressed layers.
 	MediaTypeLayerNonDistributableGzipEnc = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip+encrypted"
+	// MediaTypeLayerZstdEnc is MIME type used for non distributable encrypted zstd-compressed layers.
+	MediaTypeLayerNonDistributableZsdtEnc = "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd+encrypted"
 )

--- a/vendor/github.com/containers/ocicrypt/utils/ioutils.go
+++ b/vendor/github.com/containers/ocicrypt/utils/ioutils.go
@@ -18,9 +18,9 @@ package utils
 
 import (
 	"bytes"
+	"github.com/pkg/errors"
 	"io"
 	"os/exec"
-	"github.com/pkg/errors"
 )
 
 // FillBuffer fills the given buffer with as many bytes from the reader as possible. It returns

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -163,7 +163,7 @@ github.com/containernetworking/cni/pkg/types/create
 github.com/containernetworking/cni/pkg/types/internal
 github.com/containernetworking/cni/pkg/utils
 github.com/containernetworking/cni/pkg/version
-# github.com/containers/ocicrypt v1.1.5
+# github.com/containers/ocicrypt v1.1.6
 ## explicit
 github.com/containers/ocicrypt
 github.com/containers/ocicrypt/blockcipher


### PR DESCRIPTION
Update to ocicrypt 1.1.6 and add support for zstd type of compressed layers 