### PR TITLE
Remove references to package io/ioutil

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 linters:
   enable:
+    - depguard
     - structcheck
     - varcheck
     - staticcheck
@@ -18,3 +19,12 @@ run:
     - cmd/ctr/commands/images
     - cmd\\ctr\\commands\\run
     - cmd\\ctr\\commands\\images
+
+linters-settings:
+  depguard:
+    list-type: denylist
+    include-go-root: true
+    packages:
+      # use "io" or "os" instead
+      # https://go.dev/doc/go1.16#ioutil
+      - io/ioutil

--- a/cmd/ctd-decoder/enc_helpers.go
+++ b/cmd/ctd-decoder/enc_helpers.go
@@ -19,7 +19,6 @@ package main
 import (
 	b64 "encoding/base64"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,7 +48,7 @@ func getDecryptionKeys(keysPath string) (encconfig.CryptoConfig, error) {
 			return errors.New("Symbolic links not supported in decryption keys paths")
 		}
 
-		privateKey, err := ioutil.ReadFile(path)
+		privateKey, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/cmd/ctd-decoder/main_unix.go
+++ b/cmd/ctd-decoder/main_unix.go
@@ -20,7 +20,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -29,5 +29,5 @@ const payloadFD = 3
 func readPayload() ([]byte, error) {
 	f := os.NewFile(payloadFD, "configFd")
 	defer f.Close()
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }

--- a/cmd/ctd-decoder/main_windows.go
+++ b/cmd/ctd-decoder/main_windows.go
@@ -21,7 +21,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	winio "github.com/Microsoft/go-winio"
@@ -35,5 +35,5 @@ func readPayload() ([]byte, error) {
 		return nil, fmt.Errorf("could not DialPipe: %w", err)
 	}
 	defer conn.Close()
-	return ioutil.ReadAll(conn)
+	return io.ReadAll(conn)
 }

--- a/cmd/ctr/app/main.go
+++ b/cmd/ctr/app/main.go
@@ -18,7 +18,7 @@ package app
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/containerd/containerd/cmd/ctr/commands/content"
 	"github.com/containerd/containerd/cmd/ctr/commands/events"
@@ -46,7 +46,7 @@ var extraCmds = []cli.Command{}
 
 func init() {
 	// Discard grpc logs so that they don't mess with our stdio
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Println(c.App.Name, version.Package, c.App.Version)

--- a/images/encryption/parsehelpers/parsehelpers.go
+++ b/images/encryption/parsehelpers/parsehelpers.go
@@ -21,7 +21,6 @@ package parsehelpers
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -69,7 +68,7 @@ func processRecipientKeys(recipients []string) ([][]byte, [][]byte, [][]byte, []
 			gpgRecipients = append(gpgRecipients, []byte(value))
 
 		case "jwe":
-			tmp, err := ioutil.ReadFile(value)
+			tmp, err := os.ReadFile(value)
 			if err != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("unable to read file: %w", err)
 			}
@@ -79,7 +78,7 @@ func processRecipientKeys(recipients []string) ([][]byte, [][]byte, [][]byte, []
 			pubkeys = append(pubkeys, tmp)
 
 		case "pkcs7":
-			tmp, err := ioutil.ReadFile(value)
+			tmp, err := os.ReadFile(value)
 			if err != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("unable to read file %s: %w", value, err)
 			}
@@ -89,7 +88,7 @@ func processRecipientKeys(recipients []string) ([][]byte, [][]byte, [][]byte, []
 			x509s = append(x509s, tmp)
 
 		case "pkcs11":
-			tmp, err := ioutil.ReadFile(value)
+			tmp, err := os.ReadFile(value)
 			if err != nil {
 				return nil, nil, nil, nil, nil, nil, fmt.Errorf("unable to read file %s: %w", value, err)
 			}
@@ -118,7 +117,7 @@ func processRecipientKeys(recipients []string) ([][]byte, [][]byte, [][]byte, []
 // - <password>
 func processPwdString(pwdString string) ([]byte, error) {
 	if strings.HasPrefix(pwdString, "file=") {
-		return ioutil.ReadFile(pwdString[5:])
+		return os.ReadFile(pwdString[5:])
 	} else if strings.HasPrefix(pwdString, "pass=") {
 		return []byte(pwdString[5:]), nil
 	} else if strings.HasPrefix(pwdString, "fd=") {
@@ -179,7 +178,7 @@ func processPrivateKeyFiles(keyFilesAndPwds []string) ([][]byte, [][]byte, [][]b
 		}
 
 		keyfile := parts[0]
-		tmp, err := ioutil.ReadFile(keyfile)
+		tmp, err := os.ReadFile(keyfile)
 		if err != nil {
 			return nil, nil, nil, nil, nil, nil, err
 		}


### PR DESCRIPTION
Package io/ioutil has been marked deprecated in Go 1.16.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>