### PR TITLE
Update golangci-lint to v1.50.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.2
+          version: v1.50.1
           working-directory: src/github.com/containerd/imgcrypt
 
   tests:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 linters:
   enable:
     - depguard
-    - structcheck
-    - varcheck
     - staticcheck
     - unconvert
     - gofmt


### PR DESCRIPTION
* Updated golangci-lint version
* Removed deprecated linters

Signed-off-by: Austin Vazquez <macedonv@amazon.com>