### PR TITLE
Add Go 1.20 support to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Set env
         shell: bash
@@ -55,13 +55,13 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.2
           working-directory: src/github.com/containerd/imgcrypt
 
   tests:
     strategy:
       matrix:
-        go: [1.18, 1.19]
+        go: [1.19, 1.20]
         os: [ubuntu-22.04, windows-2022]
 
     name: Tests / ${{ matrix.os }} / ${{ matrix.go }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/imgcrypt
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Microsoft/go-winio v0.5.2


### PR DESCRIPTION
Update golangci-lint from v1.50.1 to v1.51.x for Go 1.20 support. Set minimum Go version to Go 1.20 in go.mod. Add Go 1.20 to testing matrix.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>