### PR TITLE
Abandon go 1.18 (end-of-life) and use 1.19 and 1.20 in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        go: [1.18, 1.19]
+        go: ["1.20", "1.19"]
         os: [ubuntu-22.04, windows-2022]
 
     name: Tests / ${{ matrix.os }} / ${{ matrix.go }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/imgcrypt
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Microsoft/go-winio v0.5.2

--- a/script/tests/test_encryption.sh
+++ b/script/tests/test_encryption.sh
@@ -77,6 +77,7 @@ setup() {
 
 startContainerd() {
 	cat <<_EOF_ >${CONFIG_TOML}
+version = 2
 disable_plugins = ["cri"]
 root = "${ROOTDIR}"
 state = "${STATEDIR}"
@@ -120,6 +121,7 @@ startContainerdLocalKeys() {
 	LOCAL_KEYS_PATH="${WORKDIR}/keys"
 	mkdir -p ${LOCAL_KEYS_PATH}
 	cat <<_EOF_ >${CONFIG_TOML}
+version = 2
 disable_plugins = ["cri"]
 root = "${ROOTDIR}"
 state = "${STATEDIR}"


### PR DESCRIPTION
PR https://github.com/containerd/imgcrypt/pull/109 has build failures when using go 1.18.