### PR TITLE
ci: declare contents: read on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
 
   checks:


### PR DESCRIPTION
Three jobs in `ci.yml` (`checks`, `linters`, `tests`) only do checkout + setup-go + build/test. No git push, no GitHub API write. `contents: read` at the workflow level documents that explicitly.

`codeql.yml` in this repo already declares per-job permissions (`actions: read` + `contents: read`); this brings the CI workflow in line.