### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/cmd/ctr/commands/commands.go
+++ b/cmd/ctr/commands/commands.go
@@ -69,7 +69,7 @@ func AnnotationArgs(annoStrings []string) (map[string]string, error) {
 }
 
 // PrintAsJSON prints input in JSON format
-func PrintAsJSON(x interface{}) {
+func PrintAsJSON(x any) {
 	b, err := json.MarshalIndent(x, "", "    ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "can't marshal %+v as a JSON string: %v\n", x, err)

--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -289,7 +289,7 @@ var infoCommand = cli.Command{
 			}
 			commands.PrintAsJSON(struct {
 				containers.Container
-				Spec interface{} `json:"Spec,omitempty"`
+				Spec any `json:"Spec,omitempty"`
 			}{
 				Container: info,
 				Spec:      v,

--- a/cmd/ctr/commands/run/run_unix.go
+++ b/cmd/ctr/commands/run/run_unix.go
@@ -386,7 +386,7 @@ func getRuncOptions(context *cli.Context) (*options.Options, error) {
 	return runtimeOpts, nil
 }
 
-func getRuntimeOptions(context *cli.Context) (interface{}, error) {
+func getRuntimeOptions(context *cli.Context) (any, error) {
 	// validate first
 	if (context.String("runc-binary") != "" || context.Bool("runc-systemd-cgroup")) &&
 		context.String("runtime") != "io.containerd.runc.v2" {

--- a/cmd/ctr/commands/run/run_windows.go
+++ b/cmd/ctr/commands/run/run_windows.go
@@ -152,7 +152,7 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 	}
 
 	runtime := context.String("runtime")
-	var runtimeOpts interface{}
+	var runtimeOpts any
 	if runtime == "io.containerd.runhcs.v1" {
 		runtimeOpts = &options.Options{
 			Debug: context.Bool("debug"),


### PR DESCRIPTION
Replace all occurrences of `interface{}` with `any` (introduced in Go 1.18) for modern Go idiom.

Files changed:
- `cmd/ctr/commands/commands.go`
- `cmd/ctr/commands/containers/containers.go`
- `cmd/ctr/commands/run/run_unix.go`
- `cmd/ctr/commands/run/run_windows.go`