### PR TITLE
Clear decrypted layers cache more agressively in local keys tests

### DIFF
--- a/script/tests/test_encryption.sh
+++ b/script/tests/test_encryption.sh
@@ -165,7 +165,7 @@ state = "${STATEDIR}"
 _EOF_
 	mkdir -p ${ROOTDIR}
 	mkdir -p ${STATEDIR}
-	sudo bash -c "${CONTAINERD} -c ${CONFIG_TOML} &>${LOGFILE} & echo \$! > ${PIDFILE}; wait" &
+	sudo bash -c "OCICRYPT_CONFIG=internal ${CONTAINERD} -c ${CONFIG_TOML} &>${LOGFILE} & echo \$! > ${PIDFILE}; wait" &
 	sleep 1
 	CONTAINERD_PID="$(cat ${PIDFILE})"
 	sudo kill -0 ${CONTAINERD_PID}

--- a/script/tests/test_encryption.sh
+++ b/script/tests/test_encryption.sh
@@ -210,6 +210,20 @@ pullImages() {
 	failExit $? "Image layerinfo on plain image failed"
 }
 
+remove_all_snapshots()
+{
+	local v
+
+	# to avoid caching effects of the image we just decrypted and then exported,
+	# remove all snapshots to simulate a clean system for import
+	# The following is a brute-force removal ignoring dependencies
+	while [ -n "$($CTR snapshot ls | tail -n +2)" ]; do
+		for v in $($CTR snapshot ls | tail -n +2 | cut -d" " -f1); do
+			$CTR snapshot rm $v &>/dev/null
+		done
+	done
+}
+
 setupPGP() {
 	GPGHOMEDIR=${WORKDIR}/gpg2
 
@@ -312,14 +326,9 @@ testPGP() {
 
 	# remove ${ALPINE} and ${ALPINE_ENC} to clear cached and so we need to decrypt
 	$CTR images rm --sync ${ALPINE} ${ALPINE_ENC} &>/dev/null
-	# to avoid caching effects of the image we just decrypted and then exported,
-	# remove all snapshots to simulate a clean system for import
-	# The following is a brute-force removal ignoring dependencies
-	while [ -n "$($CTR snapshot ls | tail -n +2)" ]; do
-		for v in $($CTR snapshot ls | tail -n +2 | cut -d" " -f1); do
-			$CTR snapshot rm $v &>/dev/null
-		done
-	done
+
+	remove_all_snapshots
+
 
 	$CTR images import \
 		--all-platforms \

--- a/script/tests/test_encryption.sh
+++ b/script/tests/test_encryption.sh
@@ -830,6 +830,7 @@ testLocalKeys() {
 	failExit $? "Should have been able to create a container from encrypted image when local keys exists (JWE)\n${MSG}"
 	MSG=$($CTR container rm testcontainer1 2>&1)
 	MSG=$($CTR snapshot rm testcontainer1 2>&1)
+	remove_all_snapshots
 
 	rm -f ${LOCAL_KEYS_PATH}/*
 
@@ -839,13 +840,12 @@ testLocalKeys() {
 	done
 
 	echo "Testing creation of container from encrypted image with local keys (PKCS11)"
-	MSG=$($CTR container rm testcontainer1 2>&1)
-	MSG=$($CTR snapshot rm testcontainer1 2>&1)
 	MSG=$(sudo $CTR container create --skip-decrypt-auth ${ALPINE_ENC} testcontainer1 2>&1)
 
 	failExit $? "Should have been able to create a container from encrypted image when local keys exists (PKCS11)\n${MSG}"
 	MSG=$($CTR container rm testcontainer1 2>&1)
 	MSG=$($CTR snapshot rm testcontainer1 2>&1)
+	remove_all_snapshots
 
 	$CTR images rm --sync ${ALPINE_ENC} &>/dev/null
 	echo "Encryption with ${recipient1} and ${recipient2} and decrypting with local unpack keys worked"
@@ -865,6 +865,7 @@ testLocalKeys() {
 
 	MSG=$($CTR container rm testcontainer1 2>&1)
 	MSG=$($CTR snapshot rm testcontainer1 2>&1)
+	remove_all_snapshots
 
 	# Create testcontainer1 from encrypted bash image ${BASH_ENC}
 	# Creating the container without providing (right) key must fail


### PR DESCRIPTION
Refactor the code to implement new remove_all_snapshots function and use it to aggressively clear the layer cache. It shows that the pkcs11 local keys test did not actually decrypt the layers when creating a container but it relied on cached layers instead. An updated version of the ocicrypt library is therefore needed. 